### PR TITLE
feature(notifications): add time reference to notification messages

### DIFF
--- a/client/components/admin/Notifications.jsx
+++ b/client/components/admin/Notifications.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'react-materialize';
+import moment from 'moment';
 
 /**
  * displays admin notifications
@@ -16,7 +17,7 @@ const Notifications = (props) => {
       >
         <p>
           {notification.bookTitle} {notification.type}ed
-          by {notification.username}
+          by {notification.username} {moment(notification.createdAt).fromNow()}
         </p>
       </Col>
     )

--- a/server/controllers/books.js
+++ b/server/controllers/books.js
@@ -257,6 +257,12 @@ export default {
               .then(() => {
                 book.total -= 1;
                 book.save(); // wait till book is saved before sending response
+                const notification = new Notification({
+                  type: 'borrow',
+                  bookTitle: book.title,
+                  username: req.user.username,
+                });
+                notification.save();
               })
               .then(() => res.status(200).send({
                 message: `You have successfully borrowed ${book.title}` +


### PR DESCRIPTION
#### What does this PR do?

fixes creation of notifications on initial borrowing and adds time stamps to notifications


#### How should this be manually tested?
N/A

#### Any background context you want to provide?

N/A

#### What are the relevant pivotal tracker stories?
#149760479
#149708221
